### PR TITLE
Fix bug of merging batches for validation and test steps

### DIFF
--- a/hadml/models/cgan/cond_event_gan.py
+++ b/hadml/models/cgan/cond_event_gan.py
@@ -320,7 +320,7 @@ class CondEventGANModule(LightningModule):
                     (hadrons_truths, perf['hadrons_truths']))
                 generated_event_label = perf['generated_event_label'] if len(
                     generated_event_label) == 0 else np.concatenate(
-                    (generated_event_label, perf['generated_event_label']))
+                    (generated_event_label, perf['generated_event_label'] + generated_event_label[-1] + 1))
                 observed_event_label = perf['observed_event_label'] if len(
                     observed_event_label) == 0 else np.concatenate(
                     (observed_event_label, perf['observed_event_label']))
@@ -371,7 +371,7 @@ class CondEventGANModule(LightningModule):
                 (hadrons_truths, perf['hadrons_truths']))
             generated_event_label = perf['generated_event_label'] if len(
                 generated_event_label) == 0 else np.concatenate(
-                (generated_event_label, perf['generated_event_label']))
+                (generated_event_label, perf['generated_event_label'] + generated_event_label[-1] + 1))
             observed_event_label = perf['observed_event_label'] if len(
                 observed_event_label) == 0 else np.concatenate(
                 (observed_event_label, perf['observed_event_label']))


### PR DESCRIPTION
The bug: The indices of the events in different batches were duplicate when merging in the test step for saving the data for future evaluation. This results in multiple events incorrectly assigned to the same event.

The bug didn't affect any model training and on-the-fly evaluation, but only the output data (the npz file that contains condition variables, predicted variables, and event indices)